### PR TITLE
Enable conduit Matrix server

### DIFF
--- a/modules/cloud/conduit/default.nix
+++ b/modules/cloud/conduit/default.nix
@@ -1,0 +1,41 @@
+{ pkgs, config, lib, ... }:
+
+let
+  cfg = config.cloud.conduit;
+in
+with lib;
+{
+  options.cloud.conduit = {
+    enable = mkEnableOption "Enable the conduit server";
+
+    host = mkOption {
+      type = types.str;
+      default = "m.nkagami.me";
+    };
+
+    port = mkOption {
+      type = types.int;
+      default = 6167;
+    };
+
+    allow_registration = mkOption {
+      type = types.bool;
+      default = false;
+    };
+  };
+
+  config.services.matrix-conduit = mkIf cfg.enable {
+    enable = true;
+
+    settings.global = {
+      inherit (cfg) port allow_registration;
+      server_name = cfg.host;
+      database_backend = "rocksdb";
+    };
+  };
+
+  config.cloud.traefik.hosts.conduit = mkIf cfg.enable {
+    inherit (cfg) port host;
+  };
+}
+

--- a/modules/cloud/conduit/default.nix
+++ b/modules/cloud/conduit/default.nix
@@ -40,10 +40,15 @@ with lib;
   };
 
   # Serving .well-known files
+  # This is a single .well-known/matrix/server file that points to the server,
+  # which is NOT on port 8448 since Cloudflare doesn't allow us to route HTTPS
+  # through that port.
   config.services.nginx = mkIf cfg.enable {
     enable = true;
     virtualHosts.conduit-well-kwown = {
       listen = [{ addr = "127.0.0.1"; port = cfg.well-known_port; }];
+      # Check https://github.com/spantaleev/matrix-docker-ansible-deploy/blob/master/docs/configuring-well-known.md
+      # for the file structure.
       root = pkgs.writeTextDir ".well-known/matrix/server" ''
         {
               "m.server": "${cfg.host}:443"

--- a/nki-personal-do/configuration.nix
+++ b/nki-personal-do/configuration.nix
@@ -57,7 +57,6 @@
   };
   cloud.traefik.certsDumper.enable = true;
   cloud.conduit.enable = true;
-  cloud.conduit.allow_registration = true;
 
   # Mail
   sops.secrets.mail-users = { owner = "maddy"; };

--- a/nki-personal-do/configuration.nix
+++ b/nki-personal-do/configuration.nix
@@ -7,6 +7,7 @@
     ../modules/cloud/traefik
     ../modules/cloud/bitwarden
     ../modules/cloud/mail
+    ../modules/cloud/conduit
   ];
 
   boot.cleanTmpDir = true;
@@ -55,6 +56,8 @@
     usersFile = config.sops.secrets.traefik-dashboard-users.path;
   };
   cloud.traefik.certsDumper.enable = true;
+  cloud.conduit.enable = true;
+  cloud.conduit.allow_registration = true;
 
   # Mail
   sops.secrets.mail-users = { owner = "maddy"; };


### PR DESCRIPTION
- Simple conduit instance
- Don't define allow_registration twice
- Disable registration
- Open :8448 for matrix federation
- Serve /.well-known
- Remove 8448 from firewall
- host > cfg.host
